### PR TITLE
TLS backend selection feature flags, Default, clippy

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,6 @@
 name = "fcm_v1"
 version = "0.3.0"
 edition = "2021"
-
 description = "a simple Rust FCM server library (HTTP v1 API)"
 readme = "README.md"
 homepage = "https://github.com/sanath-2024/fcm_v1"
@@ -12,12 +11,31 @@ license = "MIT"
 keywords = ["fcm", "gcp", "google", "firebase", "api"]
 categories = ["api-bindings", "web-programming"]
 
+[features]
+# See https://docs.rs/reqwest/latest/reqwest/#optional-features
+default = ["reqwest/default-tls"]
+## Enables TLS functionality provided by `native-tls`.
+native-tls = ["reqwest/native-tls"]
+## Enables the `vendored` feature of `native-tls`.
+native-tls-vendored = ["reqwest/native-tls-vendored"]
+# Enables the `alpn` feature of `native-tls`.
+#native-tls-alpn = [ "reqwest/native-tls-alpn" ]
+## Enables TLS functionality provided by `rustls`. Equivalent to `rustls-tls-webpki-roots`.
+rustls-tls = ["reqwest/rustls-tls"]
+## Enables TLS functionality provided by `rustls`, without setting any root certificates. Roots have to be specified manually.
+rustls-tls-manual-roots = ["reqwest/rustls-tls-manual-roots"]
+## Enables TLS functionality provided by `rustls`, while using root certificates from the `webpki-roots` crate.
+rustls-tls-webpki-roots = ["reqwest/rustls-tls-webpki-roots"]
+# Enables TLS functionality provided by `rustls`, while using root certificates from the `rustls-native-certs` crate.
+#rustls-tls-native-roots = [ "reqwest/rustls-tls-native-root" ]
+
 [dependencies]
 async-trait = "0.1"
-reqwest = {version = "0.11", features = ["json"]}
-serde = {version = "1", features = ["derive"]}
+document-features = "0.2.8"
+reqwest = { version = "0.11", default-features = false, features = ["json"] }
+serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 yup-oauth2 = "8.3"
 
 [dev-dependencies]
-tokio = {version = "1", features = ["macros"]}
+tokio = { version = "1", features = ["macros"] }

--- a/README.md
+++ b/README.md
@@ -1,10 +1,14 @@
-# fcm_v1
+# `fcm_v1`
 
-`fcm_v1` is a simple Rust Firebase Cloud Messaging (FCM) server library, compatible with the HTTP v1 API.
+A simple Rust
+[Firebase Cloud Messaging](https://firebase.google.com/docs/cloud-messaging)
+(FCM) server library, compatible with the HTTP v1 API.
 
 ## Goals
 
-The main goals for this library are simplicity and completeness. It should be simple enough that anyone should be able to use it without squinting at the docs for too long, yet complete enough to support the full API.
+The main goals for this library are simplicity and completeness. It should be
+simple enough that anyone should be able to use it without squinting at the docs
+for too long, yet complete enough to support the full API.
 
 ## Contributing
 

--- a/src/android.rs
+++ b/src/android.rs
@@ -25,17 +25,12 @@ pub struct AndroidConfig {
 }
 
 #[allow(missing_docs)]
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 pub enum AndroidMessagePriority {
+    #[default]
     Normal,
     High,
-}
-
-impl Default for AndroidMessagePriority {
-    fn default() -> AndroidMessagePriority {
-        AndroidMessagePriority::Normal
-    }
 }
 
 #[allow(missing_docs)]
@@ -94,37 +89,27 @@ pub struct AndroidNotification {
 }
 
 #[allow(missing_docs)]
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 pub enum NotificationPriority {
     PriorityUnspecified,
     PriorityMin,
     PriorityLow,
+    #[default]
     PriorityDefault,
     PriorityHigh,
     PriorityMax,
 }
 
-impl Default for NotificationPriority {
-    fn default() -> NotificationPriority {
-        NotificationPriority::PriorityDefault
-    }
-}
-
 #[allow(missing_docs)]
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 pub enum Visibility {
     VisibilityUnspecified,
+    #[default]
     Private,
     Public,
     Secret,
-}
-
-impl Default for Visibility {
-    fn default() -> Visibility {
-        Visibility::Private
-    }
 }
 
 #[allow(missing_docs)]

--- a/src/client.rs
+++ b/src/client.rs
@@ -86,6 +86,6 @@ impl Client {
             )));
         }
 
-        return resp.json().await.map_err(|_| Error::Deserialization);
+        resp.json().await.map_err(|_| Error::Deserialization)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,13 +1,18 @@
 #![warn(missing_docs)]
-
-//! fcm_v1
-//! ======
+//! A type-safe way to call the
+//! [Firebase Cloud Messaging](https://firebase.google.com/docs/cloud-messaging
+//! (FCM) HTTP v1 API.
 //!
-//! A type-safe way to call the Firebase Cloud Messaging (FCM) HTTP v1 API.
+//! OAuth 2.0 authentication is performed via the
+//! [`yup-oauth2`](https://crates.io/crates/yup-oauth2) crate.
 //!
-//! OAuth 2.0 authentication is performed via the [yup-oauth2](yup_oauth2) crate.
-//! Currently, we request the `"https://www.googleapis.com/auth/firebase.messaging"` scope
-//! in order to send messages.
+//! Currently, we request the
+//! `https://www.googleapis.com/auth/firebase.messaging` scope in order to send
+//! messages.
+//!
+//! ## Optional Features
+//!
+#![doc = document_features::document_features!()]
 
 /// Android-specific component of the message.
 pub mod android;


### PR DESCRIPTION
* Exposed `reqwest`'s TLS backend selection features.
   The main reason is that `request`'s default TLS dependency pulls in `openssl` which wraps the OpenSSL C-lib via `openssl-sys`.
   This not only adds a noticable hiccup to build times, it also requires a resp. C compiler toolchain which can be a PITA when cross-compilation for other platform targets is needed (e.g. Android or iOS).

   `reqwest` offers [a bunch of alternative TLS backends](https://docs.rs/reqwest/latest/reqwest/#optional-features), exposed by feature flags.

   With this PR they're all also available in the `fcm_v1` crate.

* Made `clippy` happy:
   * Swapped explicit for derived `Default` for some types.
   * Removed superfluous `return`.
* Cleaned up/added docs.